### PR TITLE
Fix score_irt() scoring responses against the wrong items (column order bug)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,9 +34,11 @@ Suggests:
     ggplot2,
     knitr,
     mirt,
-    rmarkdown
+    rmarkdown,
+    testthat (>= 3.0.0)
 Remotes:
     redivis=redivis/redivis-r
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 VignetteBuilder: knitr
+Config/testthat/edition: 3

--- a/R/irt-score.R
+++ b/R/irt-score.R
@@ -34,6 +34,13 @@ score_irt <- \(trial_data_task, mod_spec, mod_rec) {
   missing_items <- setdiff(items(mod_rec), colnames(data_prepped))
   data_aligned[,missing_items] <- NA
 
+  # reorder columns to the model's item order: mirt::fscores() matches the
+  # columns of response.pattern to the model's items by position, not by name,
+  # so a mismatched column order silently scores each response against the
+  # wrong items
+  data_aligned <- data_aligned[, items(mod_rec)]
+  stopifnot(identical(colnames(data_aligned), items(mod_rec)))
+
   # set up mirt model object for data using parameter values from model record
   mod_vals <- model_vals(mod_rec)
   if (model_class(mod_rec) == "SingleGroupClass") {

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(rlevante)
+
+test_check("rlevante")

--- a/tests/testthat/test-score_irt.R
+++ b/tests/testthat/test-score_irt.R
@@ -1,0 +1,70 @@
+# Regression test for the score_irt() column-order bug.
+#
+# mirt::fscores(mod, response.pattern = data) matches the columns of
+# response.pattern to the model's items *by position, not by name* (verified:
+# reordering named columns changes the returned theta). score_irt() must
+# therefore reorder its data to items(mod_rec) before scoring. If it does not,
+# each response vector is scored against a permuted item set, producing wrong
+# (but plausible-looking) abilities.
+#
+# The fixture uses a 2PL model with varying discrimination: under a Rasch model
+# the raw score is sufficient for EAP, so permuting columns of complete data
+# would not change the score and could not detect the bug.
+
+# build a small single-group 2PL model + ModelRecord, plus long-format trial
+# data (in a deliberately shuffled item order) that score_irt() consumes
+make_fixture <- function() {
+  skip_if_not_installed("mirt")
+
+  set.seed(123)
+  n_persons <- 400
+  item_uids <- paste0("item", 1:6)
+  discrimination <- c(0.6, 1.8, 1.0, 2.2, 0.8, 1.5)
+  difficulty <- c(-2, -1.5, -1, 0.5, 1.8, 2.5)
+  theta <- rnorm(n_persons)
+  probs <- plogis(sweep(outer(theta, difficulty, `-`), 2, discrimination, `*`))
+  # mirt item columns are item_inst names: "<item_uid>-<instance>"
+  resp <- matrix(rbinom(length(probs), 1, probs),
+                 nrow = n_persons,
+                 dimnames = list(NULL, paste0(item_uids, "-1")))
+
+  mod <- mirt::mirt(resp, 1, itemtype = "2PL", verbose = FALSE)
+  run_ids <- paste0("run", seq_len(n_persons))
+  mod_rec <- modelrecord(mod, run_ids)
+
+  # one row per run x item, as get_trials()/recode_trials() would produce.
+  # items appear in a shuffled order, so the wide column order that
+  # to_mirt_shape_grouped() produces differs from items(mod_rec).
+  item_order <- c(3, 1, 5, 2, 6, 4)
+  grid <- expand.grid(run = seq_len(n_persons), item = item_order)
+  trials <- data.frame(
+    run_id = run_ids[grid$run],
+    site = "all",
+    item_uid = item_uids[grid$item],
+    correct = as.logical(resp[cbind(grid$run, grid$item)])
+  )
+
+  mod_spec <- list(item_task = "test", dataset = "all", model_set = "test",
+                   subset = "all", itemtype = "2PL", nfact = "f1",
+                   invariance = "scalar", redivis_source = "test:abcd:v1_0")
+
+  list(mod_rec = mod_rec, trials = trials, mod_spec = mod_spec)
+}
+
+test_that("score_irt() reproduces the model's calibration EAP scores", {
+  fx <- make_fixture()
+  scored <- suppressMessages(score_irt(fx$trials, fx$mod_spec, fx$mod_rec))
+  gold <- scores(fx$mod_rec)
+  joined <- merge(scored, gold, by = "run_id")
+  expect_equal(joined$score, joined$ability, tolerance = 0.05)
+})
+
+test_that("score_irt() is invariant to the item column order of its input", {
+  fx <- make_fixture()
+  trials_fwd <- fx$trials[order(fx$trials$item_uid), ]
+  trials_rev <- fx$trials[order(fx$trials$item_uid, decreasing = TRUE), ]
+  scored_fwd <- suppressMessages(score_irt(trials_fwd, fx$mod_spec, fx$mod_rec))
+  scored_rev <- suppressMessages(score_irt(trials_rev, fx$mod_spec, fx$mod_rec))
+  joined <- merge(scored_fwd, scored_rev, by = "run_id")
+  expect_equal(joined$score.x, joined$score.y, tolerance = 1e-8)
+})


### PR DESCRIPTION
## The bug

`mirt::fscores(mod, response.pattern = data)` matches the columns of `response.pattern` to the model's items **by position, not by name** (verified empirically: reordering named columns changes the returned θ). In `score_irt()`, `data_aligned` was built as

```
[ overlap_items in data_prepped's column order ] ++ [ missing_items ]
```

whose order comes from `pivot_wider()` (first-appearance order of items in the trial data) and is essentially never equal to `items(mod_rec)`. So every response vector was scored against a **permuted item set**.

Because the permutation is fixed across runs, the resulting scores stay positively correlated with the correct ones (r ≈ 0.75–0.95), which is why this was easy to miss — scores look plausible and age-correlated, but individual θ are wrong, sometimes by several logits. This has propagated into published IRT-scored data.

Credit for finding and validating this goes to the `levante-longitudinal` analysis session: rescoring the Bogotá math calibration runs (n = 1080) correlated **0.809** with the model's own stored calibration EAP scores before the fix and **1.000** after.

## The fix

Reorder `data_aligned` to the model's item order immediately before `fscores()`, with a `stopifnot()` guard:

```r
data_aligned <- data_aligned[, items(mod_rec)]
stopifnot(identical(colnames(data_aligned), items(mod_rec)))
```

Scope: affects the IRT path only (tasks routed through `score_irt` — `matrix`, `mrot`, `math`, `hf`, `mg`, `sds`, `trog`, `vocab`, `tom`). `score_cat`, `score_sre`, `score_pa` use different code paths.

## Regression test

Adds `testthat` (new test infra for the package) with a self-contained `score_irt()` regression test. It uses a **2PL** fixture on purpose — under a Rasch model the raw score is a sufficient statistic for EAP, so permuting columns of complete data wouldn't change the score and couldn't detect the bug. The test asserts both (1) recovery of the model's own calibration EAP scores and (2) invariance to input column order. **Both fail without the fix and pass with it.**

## Not included here
Re-scoring / re-releasing the affected published datasets is a data-release task, out of scope for this package PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)