### PR TITLE
Document the scoring pipeline and model registry

### DIFF
--- a/R/fetch-processed_data.R
+++ b/R/fetch-processed_data.R
@@ -47,6 +47,12 @@ get_surveys <- function(data_source, version = "current") {
 #' Get trials
 #'
 #' `get_trials()` returns information about each trial as a data frame. See the [rlevante documentation](https://levante-framework.github.io/rlevante/index.html) for more information about how to access LEVANTE datasets and codebooks.
+#'
+#' The returned `correct` column is **not yet scoring-ready**: LEVANTE's IRT
+#' models are calibrated on trials passed through [recode_trials()] (slider
+#' thresholding, Hearts & Flowers / SDS / ToM recodes, item-key fixes, and
+#' chance backfill). Apply `recode_trials()` before scoring. See
+#' `vignette("scoring-and-model-registry")` for the full pipeline.
 #' @inheritParams get_participants
 #' @returns A data frame where each row is a trial.
 #' @export

--- a/R/irt-ModelRecord.R
+++ b/R/irt-ModelRecord.R
@@ -1,4 +1,10 @@
 #' ModelRecord class definition
+#'
+#' A fitted LEVANTE IRT model and its metadata, as stored in the model
+#' registry. Access its contents with [items()], [model_class()],
+#' [model_vals()], and [scores()]; see
+#' `vignette("scoring-and-model-registry")` for details.
+#'
 #' @keywords internal
 #'
 #' @export

--- a/R/scoring_prep_helpers.R
+++ b/R/scoring_prep_helpers.R
@@ -1,9 +1,21 @@
-#' recode correctness and/or items for several tasks
+#' Recode trial correctness for scoring
+#'
+#' `recode_trials()` applies the task-specific corrections that make
+#' [get_trials()] output scoring-ready, and **must be applied before IRT
+#' scoring**: the calibrated models were fit on recoded trials, so scoring raw
+#' `get_trials()` output yields subtly wrong values. Corrections include slider
+#' thresholding (a response is correct within `slider_threshold` of the target,
+#' with chance set to `1 / slider_threshold / 100`), Hearts & Flowers RT and
+#' start/stay/switch coding, Same/Different Selection and Theory of Mind
+#' recodes, known item-key fixes (e.g. `math_subtract_37_24`), and chance-level
+#' backfill. See `vignette("scoring-and-model-registry")`.
+#'
 #' @keywords internal
 #' @export
 #'
 #' @param df trial data
 #' @param slider_threshold max normalized distance from slider target
+#' @returns A data frame of recoded, scoring-ready trials.
 recode_trials <- \(df, slider_threshold = 0.15) {
   item_fixes <- tribble(
     ~item_uid,             ~answer_fixed,

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A collection of “get” functions to acquire LEVANTE data. For example, use ge
 ```
 scores <- get_scores(data_source = "levante-data-example:d0rt", version = "current")
 ```
+To understand how those scores are produced — and to reproduce or audit them yourself using the LEVANTE model registry — see the [Scoring and the model registry](https://levante-framework.github.io/rlevante/articles/scoring-and-model-registry.html) vignette.
 
 ### Accessing datasets and codebooks
 Permission to access the data is granted via Redivis, a data-sharing platform used for all LEVANTE datasets. Individuals seeking to access any LEVANTE data must create an account on Redivis and sign our data use agreement. 
@@ -39,3 +40,5 @@ To find and use a dataset’s reference ID, follow these steps:
 ![](man/figures/find_refIDs_step2.png)   
 
 3. Record the string used to specify the dataset, including both its name ("levante_data_pilots"") and reference ID (“68kn”). In rlevante functions, this string can be used as an argument to identify this dataset (e.g., get_participants(data_source = "levante_data_pilots:68kn")).
+
+You can also pin a specific dataset *version* by appending it to the reference, giving a fully qualified `name:hash:version` string (e.g., `get_scores(data_source = "levante_data_pilots:68kn:v1_0")`). Pinning the version makes your analysis reproducible, whereas `version = "current"` (the default) tracks the latest release. When you call a "get" function with `version = "current"`, rlevante reports the qualified reference it resolved to, which you can copy to pin future runs.

--- a/man/ModelRecord-class.Rd
+++ b/man/ModelRecord-class.Rd
@@ -6,6 +6,9 @@
 \alias{ModelRecord}
 \title{ModelRecord class definition}
 \description{
-ModelRecord class definition
+A fitted LEVANTE IRT model and its metadata, as stored in the model
+registry. Access its contents with \code{\link[=items]{items()}}, \code{\link[=model_class]{model_class()}},
+\code{\link[=model_vals]{model_vals()}}, and \code{\link[=scores]{scores()}}; see
+\code{vignette("scoring-and-model-registry")} for details.
 }
 \keyword{internal}

--- a/man/get_participants.Rd
+++ b/man/get_participants.Rd
@@ -19,6 +19,6 @@ A data frame where each row contains information about a child participant.
 }
 \examples{
 \dontrun{
-participants <- get_participants(dataset = "levante_data_example:d0rt", version = "current")
+participants <- get_participants(data_source = "levante_data_example:d0rt", version = "current")
 }
 }

--- a/man/get_scores.Rd
+++ b/man/get_scores.Rd
@@ -19,6 +19,6 @@ A data frame where each row is a task ability score. See our \href{https://resea
 }
 \examples{
 \dontrun{
-scores <- get_scores(dataset = "levante_data_example:d0rt", version = "current")
+scores <- get_scores(data_source = "levante_data_example:d0rt", version = "current")
 }
 }

--- a/man/get_surveys.Rd
+++ b/man/get_surveys.Rd
@@ -19,6 +19,6 @@ A data frame where each row is a survey item response.
 }
 \examples{
 \dontrun{
-surveys <- get_surveys(dataset = "levante_data_example:d0rt", version = "current")
+surveys <- get_surveys(data_source = "levante_data_example:d0rt", version = "current")
 }
 }

--- a/man/get_trials.Rd
+++ b/man/get_trials.Rd
@@ -17,8 +17,15 @@ A data frame where each row is a trial.
 \description{
 \code{get_trials()} returns information about each trial as a data frame. See the \href{https://levante-framework.github.io/rlevante/index.html}{rlevante documentation} for more information about how to access LEVANTE datasets and codebooks.
 }
+\details{
+The returned \code{correct} column is \strong{not yet scoring-ready}: LEVANTE's IRT
+models are calibrated on trials passed through \code{\link[=recode_trials]{recode_trials()}} (slider
+thresholding, Hearts & Flowers / SDS / ToM recodes, item-key fixes, and
+chance backfill). Apply \code{recode_trials()} before scoring. See
+\code{vignette("scoring-and-model-registry")} for the full pipeline.
+}
 \examples{
 \dontrun{
-trials <- get_trials(dataset = "levante_data_example:d0rt", version = "current")
+trials <- get_trials(data_source = "levante_data_example:d0rt", version = "current")
 }
 }

--- a/man/recode_trials.Rd
+++ b/man/recode_trials.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/scoring_prep_helpers.R
 \name{recode_trials}
 \alias{recode_trials}
-\title{recode correctness and/or items for several tasks}
+\title{Recode trial correctness for scoring}
 \usage{
 recode_trials(df, slider_threshold = 0.15)
 }
@@ -11,7 +11,18 @@ recode_trials(df, slider_threshold = 0.15)
 
 \item{slider_threshold}{max normalized distance from slider target}
 }
+\value{
+A data frame of recoded, scoring-ready trials.
+}
 \description{
-recode correctness and/or items for several tasks
+\code{recode_trials()} applies the task-specific corrections that make
+\code{\link[=get_trials]{get_trials()}} output scoring-ready, and \strong{must be applied before IRT
+scoring}: the calibrated models were fit on recoded trials, so scoring raw
+\code{get_trials()} output yields subtly wrong values. Corrections include slider
+thresholding (a response is correct within \code{slider_threshold} of the target,
+with chance set to \code{1 / slider_threshold / 100}), Hearts & Flowers RT and
+start/stay/switch coding, Same/Different Selection and Theory of Mind
+recodes, known item-key fixes (e.g. \code{math_subtract_37_24}), and chance-level
+backfill. See \code{vignette("scoring-and-model-registry")}.
 }
 \keyword{internal}

--- a/man/rlevante-package.Rd
+++ b/man/rlevante-package.Rd
@@ -23,5 +23,10 @@ Authors:
   \item Michael Frank \email{mcfrank@stanford.edu} (\href{https://orcid.org/0000-0002-7551-4378}{ORCID})
 }
 
+Other contributors:
+\itemize{
+  \item Theresa Cheng \email{twcheng@stanford.edu} (\href{https://orcid.org/0000-0002-8557-565X}{ORCID}) [contributor]
+}
+
 }
 \keyword{internal}

--- a/man/score_pa.Rd
+++ b/man/score_pa.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/irt-score.R
 \name{score_pa}
 \alias{score_pa}
-\title{scores for PA}
+\title{scores for PA -- deprecated}
 \usage{
 score_pa(trial_data_task, dataset)
 }
@@ -12,6 +12,6 @@ score_pa(trial_data_task, dataset)
 \item{dataset}{dataset}
 }
 \description{
-scores for PA
+scores for PA -- deprecated
 }
 \keyword{internal}

--- a/vignettes/rlevante_walkthrough.Rmd
+++ b/vignettes/rlevante_walkthrough.Rmd
@@ -95,3 +95,5 @@ administrations <- get_raw_table(table_name = "administrations", data_source =  
 
 administrations |> count(public_name, sort = TRUE)
 ```
+
+To go beyond loading already-scored data — understanding how LEVANTE scores are produced, and reproducing or auditing them yourself with the model registry — see the [Scoring and the model registry](scoring-and-model-registry.html) vignette.

--- a/vignettes/scoring-and-model-registry.Rmd
+++ b/vignettes/scoring-and-model-registry.Rmd
@@ -1,0 +1,181 @@
+---
+title: "Scoring and the model registry"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Scoring and the model registry}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  # the code below downloads models and data from Redivis (and fits IRT
+  # models), so it is shown for reference but not run when the vignette builds
+  eval = FALSE
+)
+```
+
+The [walkthrough vignette](rlevante_walkthrough.html) covers downloading
+*already-scored* data with `get_scores()`. This vignette is for the next step:
+understanding **how** those scores are produced, and how to reproduce or audit
+them yourself using the LEVANTE **model registry**.
+
+```{r setup}
+library(rlevante)
+library(dplyr)
+```
+
+## How LEVANTE scores are produced
+
+Most cognitive-task scores in LEVANTE are IRT ability estimates (θ). They are
+produced by fitting item-response models once (calibration) and then scoring
+each child's trial data against the appropriate fitted model. The fitted models
+and the bookkeeping needed to find them live in the
+`levante_metadata_scoring` dataset on Redivis, which rlevante reads through a
+handful of functions:
+
+| Function | Returns |
+|---|---|
+| `fetch_scoring_table()`   | which model specification applies to each (task, dataset) |
+| `fetch_registry_table()`  | an index mapping model files to Redivis file ids |
+| `fetch_registry_dir()`    | a Redivis directory handle for downloading model files |
+| `score()`                 | scores one (task, dataset) using the above |
+
+End to end, scoring a task flows like this:
+
+```
+get_trials(data_source)             # raw trial data
+   |> recode_trials()               # make trials scoring-ready (see below)
+
+fetch_scoring_table()               # look up the model spec for (task, dataset)
+fetch_registry_dir()                # handle for downloading the fitted model
+
+score(task, dataset, trials, runs,  # -> downloads the ModelRecord, shapes the
+      scoring_table, registry_dir)  #    data, rebuilds the model, scores it
+```
+
+## Pinning a dataset version
+
+Every rlevante "get" function takes a `data_source` and a `version`. For
+reproducible analyses you should pin a **fully qualified reference** of the form
+`name:hash:version` rather than relying on `version = "current"`, which silently
+tracks the latest release.
+
+```{r}
+# tracks whatever the latest release happens to be
+scores_current <- get_scores("levante_data_example:d0rt", version = "current")
+
+# pinned: name + persistent dataset id (hash) + dataset version
+scores_pinned <- get_scores("levante_data_example:d0rt:v1_0")
+```
+
+The persistent `hash` (e.g. `d0rt`) is stable even if the dataset is renamed;
+the trailing `:v1_0` pins the version. You can find both on the dataset's
+Redivis page under **API Information** → **Qualified references** (see the
+["Reference identifiers" section of the README](https://levante-framework.github.io/rlevante/index.html)).
+When you call a "get" function with `version = "current"`, rlevante emits a
+message reporting the qualified reference it resolved to, which you can copy to
+pin future runs.
+
+## Trials must be recoded before scoring
+
+`get_trials()` returns a `correct` column, but that column is **not yet
+scoring-ready**. The calibrated models were fit on data passed through
+`recode_trials()` first, so you must apply it before scoring or you will get
+subtly wrong numbers.
+
+```{r}
+trials <- get_trials("levante_data_example:d0rt") |>
+  recode_trials()
+```
+
+`recode_trials()` performs several task-specific corrections, including:
+
+- **Slider items** (e.g. number line): marks a response correct when it falls
+  within `slider_threshold` (default 0.15) of the target, and sets the chance
+  level to `1 / slider_threshold / 100` accordingly.
+- **Hearts & Flowers (`hf`)**: codes too-fast (<200 ms) and too-slow (>2000 ms)
+  responses as incorrect and labels each trial start/stay/switch.
+- **Same/Different Selection (`sds`)** and **Theory of Mind (`tom`)**: recodes
+  correctness and disaggregates items.
+- **Known item-key fixes**: e.g. `math_subtract_37_24` is rescored against the
+  corrected answer.
+
+## Rescoring a task yourself
+
+Putting it together, here is how to reproduce the scores for one task and
+dataset and compare them against the published values. The exported `score()`
+function is the high-level entry point — it looks up the model spec, downloads
+the fitted `ModelRecord`, shapes the data, and scores it.
+
+```{r}
+scoring_table <- fetch_scoring_table()
+registry_dir  <- fetch_registry_dir()
+
+task <- "math"
+dataset <- "pilot_uniandes_co_bogota"
+
+# trial (and, for adaptive tasks, run) data for this task + dataset
+trials_task <- get_trials("levante_data_example:d0rt") |>
+  recode_trials() |>
+  filter(item_task == task, dataset == !!dataset)
+
+my_scores <- score(
+  task = task, dataset = dataset,
+  trials = trials_task, runs = NULL,
+  scoring_table = scoring_table, registry_dir = registry_dir
+)
+
+# compare to the published scores
+published <- get_scores("levante_data_example:d0rt") |>
+  filter(task_id == task, dataset == !!dataset)
+
+my_scores |>
+  inner_join(published, by = "run_id", suffix = c("_mine", "_pub")) |>
+  summarise(cor = cor(score_mine, score_pub))
+```
+
+## Working with a `ModelRecord`
+
+`score()` downloads a fitted model as a `ModelRecord` object. If you want to
+inspect a model directly — for example to look up item parameters, or to
+validate a rescore — you can download one yourself from the registry. The
+accessors and slots you will need:
+
+```{r}
+# look up and download the ModelRecord for a (task, dataset)
+spec <- fetch_scoring_table() |>
+  filter(item_task == "math", dataset == "pilot_uniandes_co_bogota") |>
+  as.list()
+mod_rec <- get_registry_file(model_spec_filename(spec), fetch_registry_dir())
+```
+
+| Accessor | Returns |
+|---|---|
+| `items(mod_rec)`        | the model's item names, **in the order the model uses them** |
+| `model_class(mod_rec)`  | `"SingleGroupClass"` or `"MultipleGroupClass"` |
+| `model_vals(mod_rec)`   | the `mirt` parameter table for the fitted model |
+| `scores(mod_rec)`       | the **calibration-time** EAP scores (`run_id`, `ability`, `se`) |
+
+Some details are exposed as S4 slots:
+
+| Slot | Contents |
+|---|---|
+| `mod_rec@scores`      | calibration EAP scores (same as `scores(mod_rec)`) |
+| `mod_rec@data`        | the response matrix used to fit the model |
+| `mod_rec@groups`      | the group label of each calibration row |
+| `mod_rec@group_names` | the model's group names (for multigroup models) |
+
+Two invariants are worth knowing. First, `mod_rec@data`'s columns are
+guaranteed to be in `items(mod_rec)` order — scoring code must align new data to
+this order before calling `mirt::fscores()`, which matches columns by position.
+Second, `scores(mod_rec)` holds the EAP scores computed at calibration time on
+the full data matrix, so it is a ground-truth reference you can validate a
+rescore against:
+
+```{r}
+# rescoring the calibration runs should reproduce scores(mod_rec)$ability
+scores(mod_rec)
+```


### PR DESCRIPTION
Addresses the documentation gaps raised in the `levante-longitudinal` handoff (issue items 2a, 2c, 2e, 2f). Items 2b (exposing `levante_data_latest`), 2d (NA `difficulty`/`theta_estimate` columns), and 2g (`notebook_dataset()`) are intentionally left out per maintainer direction.

## New vignette: "Scoring and the model registry"
A companion to the data-download walkthrough that documents how scores are actually produced and how to reproduce/audit them:
- **End-to-end pipeline (2a):** `get_trials()` → `recode_trials()` → `fetch_scoring_table()` / `fetch_registry_dir()` → `score()`, with a table of the registry functions and a flow diagram.
- **Rescore-a-task worked example:** uses the exported `score()` entry point and compares against `get_scores()` output.
- **Working with a `ModelRecord` (2f):** tables of the accessors (`items()`, `model_class()`, `model_vals()`, `scores()`) and slots (`@scores`, `@data`, `@groups`, `@group_names`), and the two invariants that matter (column order = `items()` order; `@scores` is the calibration-time ground truth).
- **Version pinning (2e):** the `name:hash:version` convention.
- **Recode-before-scoring (2c):** why raw `get_trials()` output isn't scoring-ready.

All code chunks are `eval = FALSE` (they require Redivis auth and fit IMRT models), so the vignette builds without network access. I verified it knits.

## Roxygen / reference updates
- `get_trials()`: notes its `correct` column is not scoring-ready and must go through `recode_trials()` first (2c).
- `recode_trials()`: now describes what it does and that it must precede scoring (2c).
- `ModelRecord`: points to its accessors and the new vignette (2f).

## README
Adds a version-pinning note (`name:hash:version`) to the Reference identifiers section and a link to the new vignette.

## Note on extra `.Rd` changes
Regenerating roxygen also brought a few previously-stale `.Rd` files back in sync with their source (`get_scores`/`get_participants`/`get_surveys` example arg `dataset`→`data_source`, contributor list, `score_pa` title) — same as in #8, included here since this is a docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)