### PR TITLE
Tests: CI + Tier 1 scoring-pipeline unit tests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,4 +45,7 @@ jobs:
           args: 'c("--no-manual", "--ignore-vignettes")'
           build_args: 'c("--no-manual", "--no-build-vignettes")'
           upload-snapshots: true
-          error-on: '"warning"'
+          # only fail on ERRORs (which includes test failures): this package has
+          # not been through R CMD check before and may have pre-existing
+          # warnings/notes to clean up separately
+          error-on: '"error"'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,48 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Runs R CMD check (and thus testthat tests) on pushes and pull requests.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: R-CMD-check.yaml
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest, r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          # vignettes call Redivis and require credentials, so they are not
+          # built or checked in CI
+          args: 'c("--no-manual", "--ignore-vignettes")'
+          build_args: 'c("--no-manual", "--no-build-vignettes")'
+          upload-snapshots: true
+          error-on: '"warning"'

--- a/tests/testthat/test-irt-helpers.R
+++ b/tests/testthat/test-irt-helpers.R
@@ -1,0 +1,66 @@
+# Unit tests for the data-shaping helpers that turn long trial data into the
+# wide item-by-run matrices mirt expects. These run on every IRT scoring call.
+
+test_that("dedupe_items() numbers repeated items per run", {
+  df <- tibble(
+    run_id = c("r1", "r1", "r1", "r2"),
+    item_uid = c("a", "a", "b", "a")
+  )
+
+  out <- dedupe_items(df)
+
+  expect_equal(out$instance, c(1, 2, 1, 1))
+  expect_equal(as.character(out$item_inst), c("a-1", "a-2", "b-1", "a-1"))
+})
+
+test_that("to_mirt_shape() pivots to a run-by-item matrix with run_id rownames", {
+  df <- tibble(
+    run_id = c("r1", "r1", "r2"),
+    item_inst = c("a-1", "b-1", "a-1"),
+    correct = c(TRUE, FALSE, TRUE)
+  )
+
+  out <- to_mirt_shape(df)
+
+  expect_equal(rownames(out), c("r1", "r2"))
+  expect_setequal(colnames(out), c("a-1", "b-1"))
+  expect_equal(out["r1", "a-1"], 1)
+  expect_equal(out["r1", "b-1"], 0)
+  expect_true(is.na(out["r2", "b-1"]))  # r2 never saw b-1
+})
+
+test_that("to_mirt_shape_grouped() keeps the group column", {
+  df <- tibble(
+    run_id = c("r1", "r2"),
+    group = c("g1", "g2"),
+    item_inst = c("a-1", "a-1"),
+    correct = c(TRUE, FALSE)
+  )
+
+  out <- to_mirt_shape_grouped(df)
+
+  expect_equal(out$group, c("g1", "g2"))
+  expect_equal(out[["a-1"]], c(1, 0))
+})
+
+test_that("remove_no_var_items() drops items with no response variance", {
+  df <- tibble(
+    item_inst = c("novar", "novar", "var", "var"),
+    correct = c(TRUE, TRUE, TRUE, FALSE)
+  )
+
+  out <- remove_no_var_items(df)
+
+  expect_setequal(unique(out$item_inst), "var")
+})
+
+test_that("remove_nonshared_items() keeps only items present in all groups", {
+  df <- tibble(
+    item_uid = c("shared", "shared", "only_g1"),
+    group = c("g1", "g2", "g1")
+  )
+
+  out <- remove_nonshared_items(df)
+
+  expect_setequal(unique(out$item_uid), "shared")
+})

--- a/tests/testthat/test-recode.R
+++ b/tests/testthat/test-recode.R
@@ -1,0 +1,100 @@
+# Unit tests for the trial-recoding functions that make get_trials() output
+# scoring-ready. These corrections feed directly into IRT scoring, so pinning
+# their behavior guards the scoring pipeline. Inputs are tiny hand-built frames;
+# expected values are derived from the function logic.
+
+test_that("recode_slider() thresholds responses and drops out-of-range ones", {
+  # item "01_10" -> target "01" -> "0.1", max_value 10. A response is correct
+  # when abs(response - 0.1) / 10 < threshold (0.15), i.e. abs(response - 0.1) < 1.5.
+  df <- tibble(
+    item_group = "slider",
+    item = "01_10",
+    response = c("0", "5", "20"),  # within, outside, and above max_value
+    correct = NA
+  )
+
+  out <- recode_slider(df, slider_threshold = 0.15)
+
+  # the response above max_value (20 > 10) is removed
+  expect_equal(nrow(out), 2)
+  expect_equal(out$correct, c(TRUE, FALSE))
+  # original item string is retained (cols_remove = FALSE)
+  expect_true("item" %in% names(out))
+})
+
+test_that("recode_hf() codes extreme RTs incorrect and labels start/stay/switch", {
+  df <- tibble(
+    item_task = "hf",
+    run_id = "r1",
+    item_group = "g",
+    trial_number = 1:3,
+    item = c("a", "a", "b"),
+    rt_numeric = c(150, 1000, 1000),  # first is too fast (<200 ms)
+    correct = c(TRUE, TRUE, TRUE)
+  )
+
+  out <- recode_hf(df) |> arrange(trial_number)
+
+  expect_equal(out$correct, c(FALSE, TRUE, TRUE))
+  expect_equal(out$item_uid, c("g_a_start", "g_a_stay", "g_b_switch"))
+})
+
+test_that("recode_wrong_items() rescores against the corrected answer key", {
+  df <- tibble(
+    item_uid = c("math_subtract_37_24", "math_subtract_37_24", "other"),
+    response = c("13", "99", "x"),
+    correct = c(NA, NA, TRUE)
+  )
+  fixes <- tibble(item_uid = "math_subtract_37_24", answer_fixed = "13")
+
+  out <- suppressMessages(recode_wrong_items(df, fixes))
+
+  fixed <- out |> filter(item_uid == "math_subtract_37_24") |> arrange(response)
+  expect_equal(fixed$response, c("13", "99"))
+  expect_equal(fixed$correct, c(TRUE, FALSE))
+  # untouched item passes through unchanged
+  expect_true(out |> filter(item_uid == "other") |> pull(correct))
+  # the join column is dropped again
+  expect_false("answer_fixed" %in% names(out))
+})
+
+test_that("recode_tom() builds item_uid from story, group, and item", {
+  df <- tibble(
+    item_task = "tom",
+    item_original = "3_belief_story",
+    item_group = "grp",
+    item = "q1"
+  )
+
+  out <- recode_tom(df)
+
+  expect_equal(as.character(out$item_uid), "tom_story3_grp_q1")
+})
+
+test_that("recode_trials() orchestrates recodes and backfills chance", {
+  df <- tibble(
+    item_task = "math",
+    item_group = "number",
+    item = c("x", "s"),
+    item_uid = c("math_add_1_1", "math_subtract_37_24"),
+    item_original = c("x", "s"),
+    correct = c(TRUE, FALSE),
+    response = c("2", "13"),
+    rt_numeric = c(1000, 1000),
+    run_id = "r1",
+    trial_number = 1:2,
+    chance = NA_real_,
+    dataset = "d",
+    timestamp = as.POSIXct(c("2025-03-01", "2025-03-01"))
+  )
+
+  out <- suppressMessages(recode_trials(df))
+
+  # original correctness is preserved before recoding
+  orig <- out |> arrange(item_uid)
+  expect_equal(orig$original_correct, c(TRUE, FALSE))
+  # math_subtract_37_24 is rescored from FALSE to TRUE against the fixed key
+  expect_true(out |> filter(item_uid == "math_subtract_37_24") |> pull(correct))
+  # non-slider chance is backfilled to 0
+  expect_true(all(out$chance == 0))
+})

--- a/tests/testthat/test-registry-spec.R
+++ b/tests/testthat/test-registry-spec.R
@@ -1,0 +1,52 @@
+# Unit tests for the registry lookup / model-specification helpers. These build
+# the strings and filenames used to locate a fitted model in the registry, so a
+# silent change here would point scoring at the wrong (or no) model.
+
+test_that("mod_spec_str() joins non-NA spec fields with underscores", {
+  spec <- list(model_set = "multigroup_site", subset = "all_items",
+               itemtype = "Rasch", nfact = "f1", invariance = "scalar")
+  expect_equal(mod_spec_str(spec),
+               "multigroup_site_all_items_Rasch_f1_scalar")
+
+  # NA fields are dropped
+  spec_na <- modifyList(spec, list(invariance = NA, nfact = NA))
+  expect_equal(mod_spec_str(spec_na), "multigroup_site_all_items_Rasch")
+})
+
+test_that("model_spec_filename() builds the registry path", {
+  spec <- list(item_task = "math", model_set = "multigroup_site",
+               subset = "all_items", itemtype = "Rasch", nfact = "f1",
+               invariance = "scalar")
+
+  expect_equal(
+    as.character(model_spec_filename(spec)),
+    "math/multigroup_site/all_items/math_Rasch_f1_scalar.rds"
+  )
+})
+
+test_that("get_model_spec() returns a single-row spec or NULL", {
+  scoring_table <- tibble(
+    item_task = c("math", "vocab", "math"),
+    dataset = c("co", "co", "us"),
+    model_set = "multigroup_site"
+  )
+
+  spec <- get_model_spec("math", "co", scoring_table)
+  expect_type(spec, "list")
+  expect_equal(spec$item_task, "math")
+  expect_equal(spec$dataset, "co")
+
+  # no match -> NULL
+  expect_null(get_model_spec("math", "de", scoring_table))
+})
+
+test_that("translate_invariance() maps mirt invariance terms to shorthand", {
+  expect_equal(translate_invariance(""), "configural")
+  expect_equal(translate_invariance(c("slopes")), "metric")
+  expect_equal(
+    translate_invariance(c("free_means", "free_var", "intercepts", "slopes")),
+    "scalar"
+  )
+  # an unrecognized set matches nothing
+  expect_length(translate_invariance(c("intercepts")), 0)
+})

--- a/tests/testthat/test-score-simple.R
+++ b/tests/testthat/test-score-simple.R
@@ -1,0 +1,72 @@
+# Unit tests for the non-IRT scoring paths (CAT, SRE, PA). These are pure
+# transforms and don't need a fitted model.
+
+test_that("score_cat() drops runs without a theta estimate and renames", {
+  runs <- tibble(
+    run_id = c("r1", "r2", "r3"),
+    test_comp_theta_estimate = c(0.5, NA, -1.2),
+    test_comp_theta_se = c(0.3, NA, 0.4)
+  )
+
+  out <- suppressMessages(score_cat(runs))
+
+  expect_equal(out$run_id, c("r1", "r3"))
+  expect_equal(out$score, c(0.5, -1.2))
+  expect_equal(out$score_se, c(0.3, 0.4))
+  expect_true(all(out$score_type == "ability_cat"))
+})
+
+test_that("score_sre() scores within a 180-trial cap and z-scales", {
+  trials <- tibble(
+    run_id = rep(c("hi", "lo"), each = 4),
+    trial_number = rep(1:4, 2),
+    # "hi" gets all correct, "lo" gets all incorrect
+    correct = c(rep(TRUE, 4), rep(FALSE, 4))
+  )
+
+  out <- suppressMessages(score_sre(trials, dataset = "any")) |> arrange(run_id)
+
+  # z-scaled across two runs -> mean 0, and "hi" > "lo"
+  expect_equal(mean(out$score), 0, tolerance = 1e-8)
+  expect_gt(out$score[out$run_id == "hi"], out$score[out$run_id == "lo"])
+  expect_true(all(out$score_type == "guessing_adjusted_number_correct_scaled"))
+})
+
+test_that("score_sre() ignores trials beyond number 180", {
+  # two runs with distinct within-cap scores (so the z-scaling is defined)
+  base <- tibble(
+    run_id = c("a", "a", "b", "b"),
+    trial_number = c(1, 2, 1, 2),
+    correct = c(TRUE, TRUE, TRUE, FALSE)
+  )
+  # same data plus trials beyond the 180 cap, which should be ignored
+  extra <- bind_rows(base, tibble(
+    run_id = c("a", "b"),
+    trial_number = c(181, 181),
+    correct = c(FALSE, TRUE)
+  ))
+
+  out_base <- suppressMessages(score_sre(base, dataset = "any")) |> arrange(run_id)
+  out_extra <- suppressMessages(score_sre(extra, dataset = "any")) |> arrange(run_id)
+
+  expect_equal(out_extra$score, out_base$score)
+})
+
+test_that("score_pa() uses per-dataset trial maxima and drops short runs", {
+  trials <- tibble(
+    run_id = c(rep("long", 5), rep("short", 2)),
+    correct = c(TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, TRUE)
+  )
+
+  out <- suppressMessages(score_pa(trials, dataset = "pilot_uniandes_co_bogota"))
+
+  # "short" run (<= 3 trials) is dropped; "long" has 3 correct / 20 max
+  expect_equal(out$run_id, "long")
+  expect_equal(out$score, 3 / 20)
+  expect_true(all(out$score_type == "prop_correct"))
+})
+
+test_that("score_pa() returns NULL for an unknown dataset", {
+  trials <- tibble(run_id = rep("r", 5), correct = TRUE)
+  expect_null(suppressMessages(score_pa(trials, dataset = "not_a_dataset")))
+})


### PR DESCRIPTION
First of a planned series adding test coverage to the scoring/modeling pipeline. **Stacked on #9** (base is `fix-score-irt-column-order`) — review/merge #9 first; this diff is just the CI workflow and new unit tests.

## CI
Adds a standard `R-CMD-check` GitHub Action (ubuntu-release). Vignettes are skipped in CI (`--ignore-vignettes`) because their code chunks call Redivis and need credentials; the unit tests need neither network nor auth. This is the package's first test-running CI — the existing workflow only builds the pkgdown site.

## Tier 1 unit tests (pure transforms)
Hand-built tiny fixtures, expected values derived from the code:
- **recode_** (`test-recode.R`): slider thresholding + out-of-range drop, Hearts & Flowers RT cutoffs and start/stay/switch labeling, wrong-answer key fix (`math_subtract_37_24`), ToM `item_uid` construction, and `recode_trials()` orchestration incl. chance backfill.
- **IRT data shaping** (`test-irt-helpers.R`): `dedupe_items()` instance numbering, `to_mirt_shape[_grouped]()` pivots, `remove_no_var_items()`, `remove_nonshared_items()`.
- **Registry/spec** (`test-registry-spec.R`): `mod_spec_str()`, `model_spec_filename()`, `get_model_spec()` (single-row-or-NULL), `translate_invariance()`.
- **Non-IRT scoring** (`test-score-simple.R`): `score_cat()`, `score_sre()` (180-cap + z-scale), `score_pa()` (per-dataset maxima, short-run drop, unknown-dataset NULL).

All pass locally (59 assertions). Tier 2 (IRT fixture + `score_irt`/`score`/`modelrecord`) and Tier 3 (general + SDS helpers) will follow as separate stacked PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)