### PR TITLE
Tests: Tier 2 IRT model + scoring pipeline

### DIFF
--- a/tests/testthat/helper-irt.R
+++ b/tests/testthat/helper-irt.R
@@ -1,0 +1,81 @@
+# Shared IRT fixtures for the scoring/model tests. testthat sources helper-*.R
+# before the test files. These build small synthetic mirt models together with
+# the ModelRecord and long-format trial data that the scoring code consumes, so
+# the IRT tests run without any network access.
+
+# long-format trial data (one row per run x item) from a response matrix, with
+# items appearing in a chosen order. `site` is a scalar or a per-run vector.
+irt_trials_from_matrix <- function(resp, run_ids, item_uids, item_order, site) {
+  grid <- expand.grid(run = seq_along(run_ids), item = item_order)
+  site_col <- if (length(site) == 1) site else site[grid$run]
+  data.frame(
+    run_id = run_ids[grid$run],
+    site = site_col,
+    item_uid = item_uids[grid$item],
+    correct = as.logical(resp[cbind(grid$run, grid$item)])
+  )
+}
+
+# single-group 2PL fixture. 2PL (varying discrimination), not Rasch, on purpose:
+# under Rasch the raw score is sufficient for EAP, so permuting item columns
+# would not change scores and could not exercise the column-alignment logic.
+# Items appear in `item_order`, deliberately not the model's order, so the wide
+# matrix differs from items(mod_rec).
+irt_fixture_2pl <- function(n_persons = 400, item_order = c(3, 1, 5, 2, 6, 4)) {
+  skip_if_not_installed("mirt")
+
+  set.seed(123)
+  item_uids <- paste0("item", 1:6)
+  discrimination <- c(0.6, 1.8, 1.0, 2.2, 0.8, 1.5)
+  difficulty <- c(-2, -1.5, -1, 0.5, 1.8, 2.5)
+  theta <- rnorm(n_persons)
+  probs <- plogis(sweep(outer(theta, difficulty, `-`), 2, discrimination, `*`))
+  resp <- matrix(rbinom(length(probs), 1, probs),
+                 nrow = n_persons,
+                 dimnames = list(NULL, paste0(item_uids, "-1")))
+
+  mod <- mirt::mirt(resp, 1, itemtype = "2PL", verbose = FALSE)
+  run_ids <- paste0("run", seq_len(n_persons))
+  mod_rec <- modelrecord(mod, run_ids)
+  trials <- irt_trials_from_matrix(resp, run_ids, item_uids, item_order, site = "all")
+
+  spec <- list(item_task = "test", dataset = "all", model_set = "test",
+               subset = "all", itemtype = "2PL", nfact = "f1",
+               invariance = "scalar", redivis_source = "test:abcd:v1_0")
+
+  list(mod_rec = mod_rec, trials = trials, resp = resp,
+       run_ids = run_ids, item_uids = item_uids, spec = spec)
+}
+
+# two-group scalar (Rasch) multigroup fixture, to exercise the
+# MultipleGroupClass reconstruction + extract.group path in score_irt().
+irt_fixture_multigroup <- function(n_per_group = 250) {
+  skip_if_not_installed("mirt")
+
+  set.seed(321)
+  item_uids <- paste0("m", 1:5)
+  difficulty <- c(-1.2, -0.4, 0.2, 0.9, 1.6)
+  groups <- rep(c("g1", "g2"), each = n_per_group)
+  theta <- c(rnorm(n_per_group, 0), rnorm(n_per_group, 0.4))
+  probs <- plogis(outer(theta, difficulty, `-`))
+  resp <- matrix(rbinom(length(probs), 1, probs),
+                 nrow = length(groups),
+                 dimnames = list(NULL, paste0(item_uids, "-1")))
+
+  mod <- mirt::multipleGroup(
+    resp, 1, group = groups, itemtype = "Rasch",
+    invariance = c("slopes", "intercepts", "free_means", "free_var"),
+    verbose = FALSE
+  )
+  run_ids <- paste0("run", seq_along(groups))
+  mod_rec <- modelrecord(mod, run_ids)
+  trials <- irt_trials_from_matrix(resp, run_ids, item_uids,
+                                   seq_along(item_uids), site = groups)
+
+  spec <- list(item_task = "mg", dataset = "all", model_set = "test",
+               subset = "all", itemtype = "Rasch", nfact = "f1",
+               invariance = "scalar", redivis_source = "test:abcd:v1_0")
+
+  list(mod_rec = mod_rec, trials = trials, resp = resp,
+       run_ids = run_ids, groups = groups, spec = spec)
+}

--- a/tests/testthat/test-modelrecord.R
+++ b/tests/testthat/test-modelrecord.R
@@ -1,0 +1,38 @@
+# Tests for the ModelRecord constructor, accessors, slots, and S4 methods.
+
+test_that("modelrecord() accessors expose the fitted model", {
+  fx <- irt_fixture_2pl()
+  mr <- fx$mod_rec
+
+  expect_s4_class(mr, "ModelRecord")
+  expect_equal(model_class(mr), "SingleGroupClass")
+  expect_setequal(items(mr), paste0(fx$item_uids, "-1"))
+  expect_s3_class(model_vals(mr), "data.frame")
+
+  sc <- scores(mr)
+  expect_named(sc, c("run_id", "ability", "se"))
+  expect_equal(nrow(sc), length(fx$run_ids))
+  expect_setequal(sc$run_id, fx$run_ids)
+})
+
+test_that("ModelRecord @data columns are in items() order", {
+  # this is the invariant score_irt() relies on when aligning new data
+  fx <- irt_fixture_2pl()
+  expect_identical(colnames(fx$mod_rec@data), items(fx$mod_rec))
+})
+
+test_that("ModelRecord stores calibration groups for a multigroup model", {
+  fx <- irt_fixture_multigroup()
+  expect_setequal(fx$mod_rec@group_names, c("g1", "g2"))
+  expect_equal(length(fx$mod_rec@groups), length(fx$groups))
+})
+
+test_that("AIC/BIC/logLik methods return the stored fit values", {
+  fx <- irt_fixture_2pl()
+  mr <- fx$mod_rec
+
+  expect_equal(AIC(mr), mr@fit$AIC)
+  expect_equal(BIC(mr), mr@fit$BIC)
+  expect_equal(logLik(mr), mr@fit$logLik)
+  expect_type(AIC(mr), "double")
+})

--- a/tests/testthat/test-score-dispatch.R
+++ b/tests/testthat/test-score-dispatch.R
@@ -1,0 +1,47 @@
+# Tests for score()'s routing: it sends (task, dataset) to IRT scoring when the
+# scoring table has a matching spec, to a custom scorer (sre) otherwise, and
+# returns NULL when nothing applies. get_model_record() is mocked so the IRT
+# path does not touch the registry.
+
+test_that("score() routes to IRT scoring when a model spec matches", {
+  fx <- irt_fixture_2pl()
+  scoring_table <- tibble::as_tibble(fx$spec)
+
+  local_mocked_bindings(get_model_record = function(spec, registry_dir) fx$mod_rec)
+
+  scored <- suppressMessages(
+    score("test", "all", fx$trials, runs = NULL,
+          scoring_table = scoring_table, registry_dir = NULL)
+  )
+
+  expect_equal(nrow(scored), length(fx$run_ids))
+  expect_true(all(scored$score_type == "ability"))
+})
+
+test_that("score() routes to the custom sre scorer when no spec matches", {
+  # scoring table with no row for (sre, any)
+  scoring_table <- tibble::tibble(item_task = "math", dataset = "co")
+  trials <- tibble::tibble(
+    run_id = rep(c("a", "b"), each = 2),
+    trial_number = rep(1:2, 2),
+    correct = c(TRUE, TRUE, TRUE, FALSE)
+  )
+
+  scored <- suppressMessages(
+    score("sre", "any", trials, runs = NULL,
+          scoring_table = scoring_table, registry_dir = NULL)
+  )
+
+  expect_true(all(scored$score_type == "guessing_adjusted_number_correct_scaled"))
+})
+
+test_that("score() returns NULL when no scoring method applies", {
+  scoring_table <- tibble::tibble(item_task = "math", dataset = "co")
+
+  scored <- suppressMessages(
+    score("not_a_task", "any", trials = NULL, runs = NULL,
+          scoring_table = scoring_table, registry_dir = NULL)
+  )
+
+  expect_null(scored)
+})

--- a/tests/testthat/test-score-irt-paths.R
+++ b/tests/testthat/test-score-irt-paths.R
@@ -1,0 +1,48 @@
+# Tests for score_irt()'s branches beyond the simple single-group case:
+# multigroup model reconstruction, missing-item backfill, and the handling of
+# data whose group is not in the model.
+
+test_that("score_irt() reconstructs a multigroup model and scores one group", {
+  fx <- irt_fixture_multigroup()
+  g1_trials <- subset(fx$trials, site == "g1")
+
+  scored <- suppressMessages(score_irt(g1_trials, fx$spec, fx$mod_rec))
+  gold <- scores(fx$mod_rec)
+  joined <- merge(scored, gold, by = "run_id")
+
+  expect_equal(nrow(scored), sum(fx$groups == "g1"))
+  # extracting the group and scoring its calibration runs reproduces the
+  # model's stored EAP scores
+  expect_equal(joined$score, joined$ability, tolerance = 0.05)
+})
+
+test_that("score_irt() backfills items missing from the data and scores all runs", {
+  fx <- irt_fixture_2pl()
+  # drop one model item entirely from the trial data
+  missing <- subset(fx$trials, item_uid != "item3")
+
+  scored <- suppressMessages(score_irt(missing, fx$spec, fx$mod_rec))
+
+  expect_equal(nrow(scored), length(fx$run_ids))
+  expect_true(all(is.finite(scored$score)))
+})
+
+test_that("score_irt() falls back to a model group for scalar models", {
+  fx <- irt_fixture_2pl()
+  # a group not present in the model; scalar invariance -> use the model's group
+  trials_badsite <- transform(fx$trials, site = "not_a_group")
+
+  scored <- suppressMessages(score_irt(trials_badsite, fx$spec, fx$mod_rec))
+
+  expect_equal(nrow(scored), length(fx$run_ids))
+})
+
+test_that("score_irt() returns NULL for metric/configural models with an unknown group", {
+  fx <- irt_fixture_2pl()
+  trials_badsite <- transform(fx$trials, site = "not_a_group")
+
+  for (inv in c("metric", "configural")) {
+    spec <- modifyList(fx$spec, list(invariance = inv))
+    expect_null(suppressMessages(score_irt(trials_badsite, spec, fx$mod_rec)))
+  }
+})

--- a/tests/testthat/test-score_irt.R
+++ b/tests/testthat/test-score_irt.R
@@ -7,64 +7,25 @@
 # each response vector is scored against a permuted item set, producing wrong
 # (but plausible-looking) abilities.
 #
-# The fixture uses a 2PL model with varying discrimination: under a Rasch model
-# the raw score is sufficient for EAP, so permuting columns of complete data
-# would not change the score and could not detect the bug.
-
-# build a small single-group 2PL model + ModelRecord, plus long-format trial
-# data (in a deliberately shuffled item order) that score_irt() consumes
-make_fixture <- function() {
-  skip_if_not_installed("mirt")
-
-  set.seed(123)
-  n_persons <- 400
-  item_uids <- paste0("item", 1:6)
-  discrimination <- c(0.6, 1.8, 1.0, 2.2, 0.8, 1.5)
-  difficulty <- c(-2, -1.5, -1, 0.5, 1.8, 2.5)
-  theta <- rnorm(n_persons)
-  probs <- plogis(sweep(outer(theta, difficulty, `-`), 2, discrimination, `*`))
-  # mirt item columns are item_inst names: "<item_uid>-<instance>"
-  resp <- matrix(rbinom(length(probs), 1, probs),
-                 nrow = n_persons,
-                 dimnames = list(NULL, paste0(item_uids, "-1")))
-
-  mod <- mirt::mirt(resp, 1, itemtype = "2PL", verbose = FALSE)
-  run_ids <- paste0("run", seq_len(n_persons))
-  mod_rec <- modelrecord(mod, run_ids)
-
-  # one row per run x item, as get_trials()/recode_trials() would produce.
-  # items appear in a shuffled order, so the wide column order that
-  # to_mirt_shape_grouped() produces differs from items(mod_rec).
-  item_order <- c(3, 1, 5, 2, 6, 4)
-  grid <- expand.grid(run = seq_len(n_persons), item = item_order)
-  trials <- data.frame(
-    run_id = run_ids[grid$run],
-    site = "all",
-    item_uid = item_uids[grid$item],
-    correct = as.logical(resp[cbind(grid$run, grid$item)])
-  )
-
-  mod_spec <- list(item_task = "test", dataset = "all", model_set = "test",
-                   subset = "all", itemtype = "2PL", nfact = "f1",
-                   invariance = "scalar", redivis_source = "test:abcd:v1_0")
-
-  list(mod_rec = mod_rec, trials = trials, mod_spec = mod_spec)
-}
+# The fixture (irt_fixture_2pl, in helper-irt.R) uses a 2PL model with varying
+# discrimination: under a Rasch model the raw score is sufficient for EAP, so
+# permuting columns of complete data would not change the score and could not
+# detect the bug.
 
 test_that("score_irt() reproduces the model's calibration EAP scores", {
-  fx <- make_fixture()
-  scored <- suppressMessages(score_irt(fx$trials, fx$mod_spec, fx$mod_rec))
+  fx <- irt_fixture_2pl()
+  scored <- suppressMessages(score_irt(fx$trials, fx$spec, fx$mod_rec))
   gold <- scores(fx$mod_rec)
   joined <- merge(scored, gold, by = "run_id")
   expect_equal(joined$score, joined$ability, tolerance = 0.05)
 })
 
 test_that("score_irt() is invariant to the item column order of its input", {
-  fx <- make_fixture()
+  fx <- irt_fixture_2pl()
   trials_fwd <- fx$trials[order(fx$trials$item_uid), ]
   trials_rev <- fx$trials[order(fx$trials$item_uid, decreasing = TRUE), ]
-  scored_fwd <- suppressMessages(score_irt(trials_fwd, fx$mod_spec, fx$mod_rec))
-  scored_rev <- suppressMessages(score_irt(trials_rev, fx$mod_spec, fx$mod_rec))
+  scored_fwd <- suppressMessages(score_irt(trials_fwd, fx$spec, fx$mod_rec))
+  scored_rev <- suppressMessages(score_irt(trials_rev, fx$spec, fx$mod_rec))
   joined <- merge(scored_fwd, scored_rev, by = "run_id")
   expect_equal(joined$score.x, joined$score.y, tolerance = 1e-8)
 })


### PR DESCRIPTION
Second in the test series. **Stacked on #11** (base `tests-pipeline-transforms`, which is itself stacked on #9). Review/merge those first; this diff is just the IRT-fixture helper and the model/scoring tests.

## Shared fixture helper (`helper-irt.R`)
Builds small synthetic mirt models with their `ModelRecord` and long-format trial data, so the IRT tests need no network/auth:
- `irt_fixture_2pl()` — single-group 2PL (varying discrimination, items in a deliberately shuffled order).
- `irt_fixture_multigroup()` — two-group scalar (Rasch) multigroup model.

The `score_irt()` regression test from #9 is refactored onto this helper.

## New coverage
- **`score_irt()` paths** (`test-score-irt-paths.R`): multigroup reconstruction + `extract.group` (reproduces stored calibration EAP scores, cor 1.0), missing-item NA backfill (all runs still scored), scalar group fallback, and metric/configural → `NULL` when the data's group isn't in the model.
- **`ModelRecord`** (`test-modelrecord.R`): `items()`/`model_class()`/`model_vals()`/`scores()` accessors, the `@data`-in-`items()`-order invariant the scoring code depends on, multigroup group slots, and the `AIC`/`BIC`/`logLik` S4 methods.
- **`score()` dispatch** (`test-score-dispatch.R`): routes to IRT when a spec matches (with `get_model_record` mocked via `local_mocked_bindings`), to the custom `sre` scorer otherwise, and returns `NULL` when nothing applies.

All pass locally. Tier 3 (general helpers: `compute_age`, `build_filter`, `reverse_value`, and the SDS parsing/dimension helpers) will follow as the last stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)