### PR TITLE
Tests: Tier 3 general + SDS helpers

### DIFF
--- a/tests/testthat/test-pure-helpers.R
+++ b/tests/testthat/test-pure-helpers.R
@@ -1,0 +1,32 @@
+# Unit tests for small pure helpers used across the package.
+
+test_that("compute_age() returns age in years from birth month/year", {
+  # born June 2018 (assumed day 15), tested exactly six years later
+  expect_equal(compute_age(6, 2018, as.Date("2024-06-15")), 6.0)
+  # half a year later than birth midpoint
+  expect_equal(compute_age(1, 2020, as.Date("2020-07-15")), 0.5)
+  # missing inputs propagate to NA (parsed quietly)
+  expect_true(is.na(compute_age(NA, 2018, as.Date("2024-06-15"))))
+})
+
+test_that("build_filter() builds SQL WHERE clauses", {
+  expect_equal(build_filter("task_id", NULL), "")
+  expect_equal(as.character(build_filter("task_id", "math")),
+               "WHERE task_id IN ('math')")
+  expect_equal(as.character(build_filter("task_id", c("math", "vocab"))),
+               "WHERE task_id IN ('math', 'vocab')")
+  expect_equal(
+    as.character(build_filter("survey_type", "caregiver", allow_null = TRUE)),
+    "WHERE survey_type IS NULL OR survey_type IN ('caregiver')"
+  )
+})
+
+test_that("reverse_value() reverses within an ordered scale", {
+  scale <- 1:5
+  expect_equal(reverse_value(2, scale), 4)
+  expect_equal(reverse_value(1, scale), 5)
+  expect_equal(reverse_value(3, scale), 3)
+  # value not on the scale, or a scale with NA -> NA
+  expect_true(is.na(reverse_value(9, scale)))
+  expect_true(is.na(reverse_value(2, c(1, NA, 3))))
+})

--- a/tests/testthat/test-sds-helpers.R
+++ b/tests/testthat/test-sds-helpers.R
@@ -1,0 +1,61 @@
+# Unit tests for the Same/Different Selection (SDS) parsing and dimension-coding
+# helpers. These are intricate combinatorial functions with no other coverage;
+# expected values are derived by hand from the function logic.
+
+test_that("parse_response() turns a JSON-ish string into a character vector", {
+  expect_equal(
+    parse_response("{'0': 'sm-blue-triangle', '1': 'lg-yellow-triangle'}"),
+    c("sm-blue-triangle", "lg-yellow-triangle")
+  )
+  expect_equal(parse_response(NA), character(0))
+  expect_equal(parse_response("  "), character(0))
+})
+
+test_that("code_stim() infers size/color/shape with number and background defaults", {
+  expect_equal(
+    code_stim(c("med", "red", "star"), grp = "g"),
+    c(size = "med", color = "red", shape = "star",
+      number = "1", background = "white")
+  )
+  # number and background are read from the trailing parts when present
+  expect_equal(
+    code_stim(c("med", "green", "circle", "2", "black"), grp = "g"),
+    c(size = "med", color = "green", shape = "circle",
+      number = "2", background = "black")
+  )
+})
+
+test_that("code_dims() codes each stimulus in a vector", {
+  out <- code_dims(c("sm-red-star", "lg-red-circle"), grp = "g")
+  expect_length(out, 2)
+  expect_equal(out[[1]][["color"]], "red")
+  expect_equal(out[[2]][["shape"]], "circle")
+})
+
+test_that("match_opts_dims() counts matching pairs on non-constant dimensions", {
+  # three stimuli: two share color (red); size and shape all distinct; number
+  # and background are constant (and so dropped)
+  opts <- code_dims(c("sm-red-star", "lg-red-circle", "md-blue-square"), grp = "g")
+  out <- match_opts_dims(opts)
+
+  expect_equal(out[["color"]], 1)  # one red/red pair
+  expect_equal(out[["size"]], 0)   # all sizes distinct
+  expect_equal(out[["shape"]], 0)
+  expect_false("number" %in% names(out))      # constant -> dropped
+  expect_false("background" %in% names(out))
+})
+
+test_that("match_resp_dims() names dimensions the response stimuli share", {
+  resp <- code_dims(c("sm-red-star", "lg-red-circle"), grp = "g")
+  opts_dims <- c(size = 0, color = 1, shape = 0)  # as from match_opts_dims
+
+  # the two response stimuli share only color, so that's the matched dimension
+  expect_equal(match_resp_dims(resp, opts_dims), "color")
+})
+
+test_that("code_misses() returns option dimensions not covered by the response", {
+  # response covers fewer than k distinct dimensions -> the uncovered ones
+  expect_equal(code_misses(c("color", "size"), list("color"), k = 2), "size")
+  # response covers exactly k dimensions, all present in options -> no misses
+  expect_equal(code_misses(c("color"), list("color"), k = 1), character(0))
+})


### PR DESCRIPTION
Final PR in the test series. **Stacked on #12** (base `tests-irt-model`). Review/merge the earlier PRs in the chain first; this diff is just two new test files.

## Coverage
- **General pure helpers** (`test-pure-helpers.R`): `compute_age()` (incl. NA propagation), `build_filter()` (NULL / single / multi-value / `allow_null` SQL WHERE clauses), `reverse_value()` (survey reverse-coding edge cases).
- **SDS helpers** (`test-sds-helpers.R`): the Same/Different Selection parsing and dimension-coding chain — `parse_response`, `code_stim`, `code_dims`, `match_opts_dims`, `match_resp_dims`, `code_misses` — which had no prior coverage. Expected values derived by hand from the function logic.

All pass locally. This completes Tiers 1–3 of the test plan (Tier 4 / gated integration was intentionally deferred).

## Full stack
#9 (fix) → #11 (CI + Tier 1) → #12 (Tier 2 IRT) → #13 (this). Merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)