### PR TITLE
Revive item-ID conflict validation in add_item_ids()

### DIFF
--- a/R/process-trials.R
+++ b/R/process-trials.R
@@ -223,10 +223,13 @@ add_item_ids <- function(trials) {
     summarise(item_uid_source = list(.data$item_uid_source)) |>
     ungroup()
 
-  # check that no trials have multiple conflicted item IDs
+  # validate that no trial maps to multiple conflicting item IDs
   conflicts <- trials_mapped |> group_by(.data$trial_id) |> filter(n() > 1) |> ungroup()
-  # message(nrow(conflicts))
-  # assertthat::assert_that(nrow(conflicts) == 0)
+  if (nrow(conflicts) > 0) {
+    warning(glue::glue("{n_distinct(conflicts$trial_id)} trial(s) map to multiple ",
+                       "conflicting item IDs and may be scored incorrectly"),
+            call. = FALSE)
+  }
 
   # join mapped trials back into overall trials
   trials_prepped |>


### PR DESCRIPTION
Revives the disabled conflict check in `add_item_ids()` (`process-trials.R`). It already computed `conflicts` (trials mapping to more than one item ID) but the assertion was commented out (`# assertthat::assert_that(nrow(conflicts) == 0)`). Now it actively **warns** when any trial maps to multiple conflicting item IDs.

Two deliberate choices:
- **Warning, not hard stop.** I couldn't verify against live data whether current data is conflict-free (the `process_*` path currently fails against the installed redivis version — separate known issue), and the check may have been disabled because it was firing. A warning surfaces the problem without breaking `process_trials` for everyone. One-line change to `stop()` if you want it enforced.
- **Base R, not `assertthat`** — `assertthat` isn't a dependency.

(The dead-code removals — `code_numberline`, `convert_rts` — are split out into a separate PR for independent review, per request.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)