### PR TITLE
Remove unused helpers (code_numberline, convert_rts)

### DIFF
--- a/R/process-trials.R
+++ b/R/process-trials.R
@@ -257,18 +257,3 @@ convert_rts <- function(trials) {
   trials |> mutate(rt_numeric = suppressWarnings(as.numeric(.data$rt)),
                    .after = .data$rt)
 }
-
-code_numberline <- function(trials, threshold = 0.15) {
-  slider_trials <- trials |>
-    filter(.data$item_group == "slider") |>
-    tidyr::separate_wider_delim(.data$item, "_",
-                                names = c("answer", "max_value"),
-                                cols_remove = FALSE) |>
-    mutate(answer = .data$answer |> stringr::str_replace("^0", "0."),
-           across(c(.data$answer, .data$max_value), as.numeric),
-           correct = (abs(as.numeric(.data$response) - .data$answer) / .data$max_value < threshold)) |>
-    select(-c("answer", "max_value"))
-  trials |>
-    filter(.data$item_group != "slider") |>
-    bind_rows(slider_trials)
-}

--- a/R/process-trials.R
+++ b/R/process-trials.R
@@ -251,9 +251,3 @@ add_item_metadata <- function(trials) {
            entry = tidyr::replace_na(.data$entry, "")) |>
     rename(item_original = "item", item_group = "group", item = "entry")
 }
-
-# add numeric RTs
-convert_rts <- function(trials) {
-  trials |> mutate(rt_numeric = suppressWarnings(as.numeric(.data$rt)),
-                   .after = .data$rt)
-}


### PR DESCRIPTION
Removes two helper functions in `process-trials.R` that are defined but never called anywhere in the package. Split into one commit each so each removal can be reviewed/reverted independently.

- **`code_numberline()`** — `recode_slider()` is the live slider-scoring path; this is a dead parallel implementation.
- **`convert_rts()`** — never invoked. `process_trials()` selects `rt_numeric` straight from the source data without calling it, so removal is behavior-preserving.

I confirmed the package still loads with both gone. Flagged for human review since "unused" is a judgment call.

(Split off from #14, which now contains only the `add_item_ids()` validation revival.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)