### PR TITLE
Fix recode_wrong_items() injecting a phantom row for absent items

### DIFF
--- a/R/scoring_prep_helpers.R
+++ b/R/scoring_prep_helpers.R
@@ -81,8 +81,11 @@ recode_slider <- \(df, slider_threshold) {
 #' @inheritParams recode_trials
 #' @param wrong_items tibble with columns item_uid and answer_fixed
 recode_wrong_items <- \(df, wrong_items) {
+  # inner_join (not right_join): only recode wrong-answer items that are
+  # actually present. right_join would keep unmatched wrong_items keys, adding
+  # a spurious all-NA trial row when an item bank entry isn't in the data.
   wrong_trials <- df |>
-    right_join(wrong_items) |>
+    inner_join(wrong_items) |>
     mutate(correct = !is.na(.data$response) & .data$response == .data$answer_fixed)
   df |>
     anti_join(wrong_items) |>

--- a/tests/testthat/test-recode.R
+++ b/tests/testthat/test-recode.R
@@ -58,6 +58,23 @@ test_that("recode_wrong_items() rescores against the corrected answer key", {
   expect_false("answer_fixed" %in% names(out))
 })
 
+test_that("recode_wrong_items() adds no row when the fixed item is absent", {
+  # data contains none of the wrong-answer items; output must be unchanged and
+  # must NOT gain a spurious all-NA row for the missing item bank entry
+  df <- tibble(
+    item_uid = c("other1", "other2"),
+    response = c("a", "b"),
+    correct = c(TRUE, FALSE)
+  )
+  fixes <- tibble(item_uid = "math_subtract_37_24", answer_fixed = "13")
+
+  out <- suppressMessages(recode_wrong_items(df, fixes))
+
+  expect_equal(nrow(out), 2)
+  expect_setequal(out$item_uid, c("other1", "other2"))
+  expect_false(any(is.na(out$item_uid)))
+})
+
 test_that("recode_tom() builds item_uid from story, group, and item", {
   df <- tibble(
     item_task = "tom",


### PR DESCRIPTION
**Stacked on #11** (needs its `test-recode.R`). Fixes the latent recode bug surfaced earlier.

## The bug
`recode_wrong_items()` used `right_join(wrong_items)`, which keeps *unmatched* `wrong_items` keys. When an item-bank fix entry (currently just `math_subtract_37_24`) isn't present in the data you're recoding — e.g. a single-task or single-site subset — the join adds a spurious **all-NA trial row** (NA `run_id`, `item_uid`, etc.) that then flows downstream into `dedupe_items()` / scoring.

It's the same silent class as the original scoring bug: nothing errors, the output just quietly gains a bogus row.

## The fix
`right_join` → `inner_join`: only recode items actually present. Behavior is identical when the item *is* present (the matched rows are the same), so the `math_subtract_37_24` answer-key correction is unchanged.

## Test
Adds a regression test asserting no row is added when the fixed item is absent (fails on `right_join`, passes on `inner_join`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)