### PR TITLE
Guard recode_trials() against double application

### DIFF
--- a/R/scoring_prep_helpers.R
+++ b/R/scoring_prep_helpers.R
@@ -5,6 +5,16 @@
 #' @param df trial data
 #' @param slider_threshold max normalized distance from slider target
 recode_trials <- \(df, slider_threshold = 0.15) {
+  # recode_trials() is not idempotent: re-applying it double-applies item-id
+  # transforms (e.g. the Hearts & Flowers start/stay/switch suffixes), silently
+  # corrupting item_uids. It adds an `original_correct` column, so guard against
+  # being run on already-recoded data.
+  if ("original_correct" %in% names(df)) {
+    stop("recode_trials() has already been applied to this data (an ",
+         "`original_correct` column is present); apply it exactly once.",
+         call. = FALSE)
+  }
+
   item_fixes <- tribble(
     ~item_uid,             ~answer_fixed,
     "math_subtract_37_24", "13"

--- a/tests/testthat/test-recode.R
+++ b/tests/testthat/test-recode.R
@@ -115,3 +115,25 @@ test_that("recode_trials() orchestrates recodes and backfills chance", {
   # non-slider chance is backfilled to 0
   expect_true(all(out$chance == 0))
 })
+
+test_that("recode_trials() refuses to recode already-recoded data", {
+  df <- tibble(
+    item_task = "math",
+    item_group = "number",
+    item = c("x", "s"),
+    item_uid = c("math_add_1_1", "math_subtract_37_24"),
+    item_original = c("x", "s"),
+    correct = c(TRUE, FALSE),
+    response = c("2", "13"),
+    rt_numeric = c(1000, 1000),
+    run_id = "r1",
+    trial_number = 1:2,
+    chance = NA_real_,
+    dataset = "d",
+    timestamp = as.POSIXct(c("2025-03-01", "2025-03-01"))
+  )
+
+  once <- suppressMessages(recode_trials(df))
+  # recoding the already-recoded output (which now has original_correct) errors
+  expect_error(recode_trials(once), "already been applied")
+})


### PR DESCRIPTION
**Stacked on #16.** Addresses the non-idempotence bug surfaced by the pipeline probes.

## The problem
`recode_trials()` is not idempotent. Applying it twice double-applies the item-id transforms — Hearts & Flowers is the clearest case:
```
once:  g_a_start | g_a_stay        | g_b_switch
twice: g_a_start_start | g_a_stay_switch | g_b_switch_switch
```
The corrupted `item_uid`s then silently fail to match the model's items during scoring — the same quiet class of failure as the original column-order bug.

## The guard
`recode_trials()` adds an `original_correct` column as its first step, so that column's presence is a reliable marker that the data was already recoded. The function now **errors** in that case instead of corrupting the data. Includes a regression test.

I chose error over silent no-op: for a pipeline that produces published scores, you want to know your pipeline is double-recoding, not have it quietly absorbed. Trivial to switch to a no-op if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)