### PR TITLE
Document the fixed guessing asymptote (item_parameters omits g)

### DIFF
--- a/vignettes/scoring-and-model-registry.Rmd
+++ b/vignettes/scoring-and-model-registry.Rmd
@@ -179,3 +179,44 @@ rescore against:
 # rescoring the calibration runs should reproduce scores(mod_rec)$ability
 scores(mod_rec)
 ```
+
+## The guessing parameter (lower asymptote)
+
+The deployed IRT models include a **fixed guessing lower asymptote** at each
+item's chance level (`g = chance`, held fixed rather than estimated).
+`score_irt()` rebuilds the full model from `model_vals(mod_rec)` — which
+includes these `g` rows — so the released ability scores already account for
+guessing.
+
+Two things are easy to get wrong here:
+
+- The `item_parameters` table (and `get_item_parameters()`) exposes only
+  `difficulty` and `discrimination`; it **omits `g`**. Its `itemtype` label
+  (`rasch` / `2pl`) describes the discrimination structure only, not the
+  presence of guessing.
+- The **authoritative, complete** parameter set is `model_vals(mod_rec)` (i.e.
+  `mirt::mod2values()`), which includes the slope `a`, intercept/difficulty
+  `d` / `b`, the guessing asymptote `g`, and the upper asymptote `u`.
+
+To read each item's fixed guessing value:
+
+```{r}
+model_vals(mod_rec) |>
+  filter(name == "g") |>
+  select(item, value)   # e.g. 0.25 for a 4-AFC task such as matrix
+```
+
+If you reconstruct an item response function yourself — for person-fit,
+test-information, simulation, or independent rescoring — you **must** include
+the asymptote:
+
+```
+P(theta) = g + (1 - g) * plogis(a * (theta - b))
+```
+
+Reconstructing a plain logistic without `g` silently mismatches the fitted
+model and inflates residuals at low ability (lucky guesses on hard items look
+"impossible"), which can corrupt person-fit and reliability analyses even
+though the released scores themselves are correct. The trial-level `chance`
+field from `get_trials()` carries the same per-item `g` values, so it is an
+equivalent source for the asymptote.


### PR DESCRIPTION
Addresses the guessing-parameter handoff. **Not a scoring bug** — released scores are correct; this is metadata/documentation completeness. **Stacked on #10** (extends the scoring vignette it adds).

## The gap
The deployed IRT models incorporate guessing as a **fixed lower asymptote at each item's chance level** (`g = chance`, `est = FALSE`). `score_irt()` rebuilds the full model from `model_vals()` (which includes the `g` rows), so released θ̂ already account for it. But the curated `item_parameters` table — and `get_item_parameters()` — expose only `difficulty` and `discrimination` and **silently omit `g`** (confirmed: its columns are `task_id, item_task, item_uid, difficulty, discrimination, n_responses, model_set, subset, itemtype, nfact, invariance`). Anyone reconstructing the IRF from that table alone builds a plain logistic with no lower asymptote, which mismatches the fitted model and inflates low-ability residuals (person-fit, reliability, simulation, independent rescoring).

## This PR
Adds a "guessing parameter (lower asymptote)" section to the scoring vignette:
- `model_vals(mod_rec)` (= `mirt::mod2values()`) is the **authoritative, complete** parameter set (`a`, `d`/`b`, **`g`**, `u`).
- a one-liner to read each item's fixed `g` (`model_vals(mod_rec) |> filter(name == "g")`),
- the IRF reconstruction formula `P = g + (1 - g) * plogis(a * (theta - b))`,
- the warning that `item_parameters` omits `g`, and that the trial-level `chance` field carries the same values.

## Scope note
The handoff's option #1 (add a `guessing` column to the `item_parameters` table) belongs to the **upstream scoring/calibration pipeline** that produces that table, not rlevante — `get_item_parameters()` just reads it from Redivis. So the rlevante-side fix is documentation (the handoff says "do #2 regardless"). I'm also adding a one-line caveat to `get_item_parameters()`'s own help page over on #8 (it's where that function is defined). Acceptance criteria (obtain `g` via a documented one-liner; docs warn the table omits it and that IRF reconstruction needs the asymptote) are met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)